### PR TITLE
refactor(hooks): with custom callback

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -20,11 +20,9 @@ export type Files = {
 
 function useInputFile({ ref, options }: Args, callback?: Callback): Files {
   const [files, setFiles] = useState<FileList | null>(null);
-  const customerHandler = useRef<(event: Event) => void>();
+  const customerHandler = useRef<Callback | undefined>(undefined);
 
-  useEffect(() => {
-    customerHandler.current = callback;
-  }, [callback]);
+  customerHandler.current = callback;
 
   useEffect(() => {
     const input = ref.current as HTMLInputElement;


### PR DESCRIPTION
1. Using return files
```ts
const ref = useRef<HTMLInputElement>(null);
const { files } = useInputFile(ref);

// Handling files...
```

2. Use callback
```ts
const ref = useRef<HTMLInputElement>(null);
const [files, setFiles] = React.useState<FileList | null>(null);

useInputFile({ ref }, event => {
  const result = (event.currentTarget as HTMLInputElement).files;

  setFiles(result);
});
```